### PR TITLE
Fix crash when ssh key given from command line

### DIFF
--- a/lib/kontena/plugin/upcloud/prompts.rb
+++ b/lib/kontena/plugin/upcloud/prompts.rb
@@ -66,7 +66,7 @@ module Kontena
           end
 
           def ssh_key
-            return File.read(ssh_key_path) unless ssh_key_path.nil?
+            return File.read(ssh_key_path).strip unless ssh_key_path.nil?
             default = File.read(Defaults::DEFAULT_SSH_KEY_PATH).strip rescue nil
             prompt.ask('SSH public key: (enter an ssh key in OpenSSH format "ssh-xxx xxxxx key_name")', default: default) do |q|
               q.validate /^ssh-rsa \S+ \S+$/


### PR DESCRIPTION
Fixes #25

The trailing linefeed was not removed from ssh public key when set through command line parameter.
